### PR TITLE
Update cats-parse, cats-core, scala 3 and scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPrev
 
 name := "scala-uri root"
 
-ThisBuild / scalaVersion       := "3.2.2"
+ThisBuild / scalaVersion       := "3.3.1"
 ThisBuild / crossScalaVersions := Seq("2.12.17", "2.13.10", scalaVersion.value)
 publish / skip                 := true // Do not publish the root project
 
@@ -66,8 +66,8 @@ val scalaUriSettings = Seq(
   name        := "scala-uri",
   description := "Simple scala library for building and parsing URIs",
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "cats-core"  % "2.9.0",
-    "org.typelevel" %%% "cats-parse" % "0.3.9"
+    "org.typelevel" %%% "cats-core"  % "2.10.0",
+    "org.typelevel" %%% "cats-parse" % "1.0.0"
   ),
   libraryDependencies ++= (if (isScala3.value) Nil else Seq("com.chuusai" %%% "shapeless" % "2.3.10")),
   pomPostProcess := { node =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.6")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 


### PR DESCRIPTION
Updating cats-parse forces a bunch of other updates, including to scala.js >= 1.13

Now a test under scala.js fails, that worked before (for both scala.js 1.13.2 and 1.14.0):

    [info] - should result in a None *** FAILED ***
    [info]   org.scalajs.linker.runtime.UndefinedBehaviorError: java.lang.NullPointerException
    [info]   at $throwNullPointerException(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:70:9)
    [info]   at $n(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:74:5)
    [info]   at io.lemonlabs.uri.Uri$.parseTry(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:7205:54)
    [info]   at io.lemonlabs.uri.Uri$.parseOption(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:7225:18)
    [info]   at io.lemonlabs.uri.ParsingTests.testFun$proxy6$1(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:162102:51)
    [info]   at {anonymous}()(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:163580:52)
    [info]   at scala.scalajs.runtime.AnonFunction0.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:76507:43)
    [info]   at org.scalatest.Transformer.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:104706:63)
    [info]   at org.scalatest.Transformer.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:104728:15)
    [info]   at org.scalatest.flatspec.AnyFlatSpecLike$$anon$5.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:88653:166)
    [info]   ...
    [info]   Cause: java.lang.NullPointerException:
    [info]   at $throwNullPointerException(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:70:97)
    [info]   at $n(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:74:5)
    [info]   at io.lemonlabs.uri.Uri$.parseTry(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:7205:54)
    [info]   at io.lemonlabs.uri.Uri$.parseOption(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:7225:18)
    [info]   at io.lemonlabs.uri.ParsingTests.testFun$proxy6$1(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:162102:51)
    [info]   at {anonymous}()(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:163580:52)
    [info]   at scala.scalajs.runtime.AnonFunction0.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:76507:43)
    [info]   at org.scalatest.Transformer.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:104706:63)
    [info]   at org.scalatest.Transformer.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:104728:15)
    [info]   at org.scalatest.flatspec.AnyFlatSpecLike$$anon$5.apply(/home/ben/Projects/scala-uri/js/target/scala-3.3.1/scala-uri-test-fastopt/main.js:88653:166)
    [info]   ...

The [cause is this line](https://github.com/cptwunderlich/scala-uri/blob/master/shared/src/main/scala/io/lemonlabs/uri/Uri.scala#L108): `Try(s.toString).flatMap(UriParser.parseUri)` where `s` is `null`. In Scala (jvm), the Try catches the NullPointerException, in scala.js it seems not to.
